### PR TITLE
Improve travis-ci test and deploy phases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,35 @@
 language: java
 jdk:
   - oraclejdk8
+  - openjdk8
+  - openjdk11
+matrix:
+  allow_failures:
+    - jdk: openjdk11
 install:
   - mvn --settings .travis/settings.xml install -DskipTests=true -Dgpg.skip -Dmaven.javadoc.skip=true -B -V
 before_install:
   - if [ ! -z "$GPG_SECRET_KEYS" ]; then echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import; fi
   - if [ ! -z "$GPG_OWNERTRUST" ]; then echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust; fi
-deploy:
-  -
-    provider: script
-    script: .travis/deploy.sh
-    skip_cleanup: true
-    on:
-      repo: rapid7/recog-java
-      branch: master
+script:
+  - mvn integration-test -Dgpg.skip -Dmaven.javadoc.skip=true -B -V
+jobs:
+  include:
+    - stage: deploy
+      if: branch = master
       jdk: oraclejdk8
-  -
-    provider: script
-    script: .travis/deploy.sh
-    skip_cleanup: true
-    on:
-      repo: rapid7/recog-java
-      tags: true
-      jdk: oraclejdk8
+      deploy:
+        -
+          provider: script
+          script: .travis/deploy.sh
+          skip_cleanup: true
+          on:
+            repo: rapid7/recog-java
+            branch: master
+        -
+          provider: script
+          script: .travis/deploy.sh
+          skip_cleanup: true
+          on:
+            repo: rapid7/recog-java
+            tags: true

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
   </distributionManagement>
 
   <properties>
-    <r7.recog.content.version>2.1.19</r7.recog.content.version>
+    <r7.recog.content.version>2.1.32</r7.recog.content.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -213,6 +213,7 @@
         <executions>
           <execution>
             <id>checkstyle</id>
+            <phase>validate</phase>
             <goals>
               <goal>check</goal>
             </goals>
@@ -259,7 +260,7 @@
             <id>recog-download</id>
             <phase>pre-integration-test</phase>
             <configuration>
-              <tasks>
+              <target>
                 <mkdir dir="${project.build.directory}/recog"/>
                 <get src="http://production.cf.rubygems.org/gems/recog-${r7.recog.content.version}.gem" dest="${project.build.directory}/recog/recog-${r7.recog.content.version}.tar" usetimestamp="true"/>
                 <untar src="${project.build.directory}/recog/recog-${r7.recog.content.version}.tar" dest="${project.build.directory}/recog"/>
@@ -269,7 +270,7 @@
                   </patternset>
                   <mapper type="flatten"/>
                 </untar>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>


### PR DESCRIPTION
## Description
- Add OpenJDK 8 and 11 runtimes
- Make sure checkstyle and integration tests also run during test phase
- Move deploy into a stage so it only runs once after tests pass
- Update recog content version to latest, and fix deprecation warning for ant-run plugin


## Motivation and Context
I wanted to make sure that all tests are running appropriately and that deploys don't get cluttered in test runs.


## How Has This Been Tested?
This pull request will be tested!
