### PR TITLE
DCA-22136 Fix empty name parameter 

### DIFF
--- a/src/main/java/com/rapid7/recog/parser/RecogParser.java
+++ b/src/main/java/com/rapid7/recog/parser/RecogParser.java
@@ -73,7 +73,7 @@ public class RecogParser {
    *         if no matchers are defined, or all matchers are invalid and strict mode is disabled.
    * @throws ParseException If an error is encountered and strict-mode is enabled.
    */
-  public RecogMatchers parse(Reader reader, String name) // TODO: what was name meant to be used for?
+  public RecogMatchers parse(Reader reader, String name)
       throws ParseException {
     Document document;
     try {
@@ -99,9 +99,8 @@ public class RecogParser {
 
     String recogKey = root.getAttribute("matches");
 
-    if (recogKey.isEmpty() || recogKey == null)
-    {
-       LOGGER.warn("Recog Matcher Key is Empty or Null. File Name: " + name);
+    if (recogKey.isEmpty() || recogKey == null) {
+       LOGGER.debug("Recog Matcher Key is Empty or Null. File Name: " + name);
        recogKey = name;
     }
 

--- a/src/main/java/com/rapid7/recog/parser/RecogParser.java
+++ b/src/main/java/com/rapid7/recog/parser/RecogParser.java
@@ -100,8 +100,8 @@ public class RecogParser {
     String recogKey = root.getAttribute("matches");
 
     if (recogKey.isEmpty() || recogKey == null) {
-       LOGGER.debug("Recog Matcher Key is Empty or Null. File Name: " + name);
-       recogKey = name;
+      LOGGER.debug("Recog Matcher Key is Empty or Null. File Name: " + name);
+      recogKey = name;
     }
 
     RecogMatchers matchers = new RecogMatchers(recogKey, root.getAttribute("protocol"), root.getAttribute("database_type"), preference);


### PR DESCRIPTION
## Description
This fixes an old to-do, and uses the file name as the matcher "key" if the recog does not provide a `matches` value. 


## Motivation and Context
As part of work being done to capture missing Recog banners, it was discovered that in some cases the attempted matcher was unknown. This addresses the issue. 


## How Has This Been Tested?
This has been tested in local scans. 


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)



## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
