### PR TITLE
Add JDK 17 test target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 11 ]
+        java: [ 8, 11, 17 ]
 
     steps:
       - uses: actions/checkout@v2
       - name: Setup java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: zulu
           java-version: ${{ matrix.java }}
       - name: Cache Maven packages
         uses: actions/cache@v2


### PR DESCRIPTION
## Description
Update setup-java action to v2 (which now requires the `distribution` parameter) and add JDK 17 target to test the latest LTS release.


## Motivation and Context
The latest LTS release of Java is available so we should run tests on it.


## How Has This Been Tested?
This PR should have test results


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
N/A just adding a test target platform


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
