### PR TITLE
Fix build issue with newer JDK versions

### DIFF
--- a/src/main/java/com/rapid7/recog/provider/RecogMatchersProvider.java
+++ b/src/main/java/com/rapid7/recog/provider/RecogMatchersProvider.java
@@ -86,7 +86,7 @@ public class RecogMatchersProvider implements IRecogMatchersProvider, Serializab
     if (Files.isDirectory(path)) {
       parseFromWalkablePath(path);
     } else if (Files.isRegularFile(path) && path.getFileName().toString().endsWith(".zip")) {
-      try (FileSystem fs = FileSystems.newFileSystem(path, null)) {
+      try (FileSystem fs = FileSystems.newFileSystem(path, (java.lang.ClassLoader)null)) {
         parseFromWalkablePath(fs.getRootDirectories().iterator().next());
       } catch (IOException exception) {
         LOGGER.warn("Failed to open zip file {}.", path, exception);


### PR DESCRIPTION
## Description
Fixes a build issue with `RecogMatchersProvider` and newer JDK versions.

```
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /recog-java/src/main/java/com/rapid7/recog/provider/RecogMatchersProvider.java:[89,39] reference to newFileSystem is ambiguous
  both method newFileSystem(java.nio.file.Path,java.lang.ClassLoader) in java.nio.file.FileSystems and method newFileSystem(java.nio.file.Path,java.util.Map<java.lang.String,?>) in java.nio.file.FileSystems match
[INFO] 1 error
```


## Motivation and Context
Fixing bugs and working with newer JDKs!



## How Has This Been Tested?
Tested build (`mvn compile`) using both openjdk `11.0.11` and `16.0.1`.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
