### PR TITLE
Update dependencies and checkstyle plugin

### DIFF
--- a/google_checks.xml
+++ b/google_checks.xml
@@ -136,13 +136,17 @@
     </module>
     <module name="JavadocMethod">
       <property name="severity" value="ignore"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="accessModifiers" value="public"/>
+      <property name="allowMissingParamTags" value="true"/>
+      <property name="allowMissingReturnTag" value="true"/>
+      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
+    </module>
+    <module name="MissingJavadocMethod">
+      <property name="severity" value="ignore"/>
       <property name="minLineCount" value="2"/>
       <property name="allowedAnnotations" value="Override, Test"/>
       <property name="scope" value="public"/>
-      <property name="allowThrowsTagsForSubclasses" value="true"/>
-      <property name="allowMissingParamTags" value="true"/>
-      <property name="allowMissingThrowsTags" value="true"/>
-      <property name="allowMissingReturnTag" value="true"/>
       <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
     </module>
     <module name="MethodName">

--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,11 @@
     <commons.cli.version>1.4</commons.cli.version>
     <slf4j.version>1.7.25</slf4j.version>
     <!-- test dependencies -->
-    <commons.io.version>2.6</commons.io.version>
-    <commons.lang3.version>3.8.1</commons.lang3.version>
-    <hamcrest.version>1.3</hamcrest.version>
-    <junit.jupiter.version>5.4.0</junit.jupiter.version>
-    <mockito.version>2.18.0</mockito.version>
+    <commons.io.version>2.11.0</commons.io.version>
+    <commons.lang3.version>3.12.0</commons.lang3.version>
+    <hamcrest.version>2.2</hamcrest.version>
+    <junit.jupiter.version>5.8.1</junit.jupiter.version>
+    <mockito.version>3.12.4</mockito.version>
   </properties>
 
   <dependencyManagement>
@@ -172,7 +172,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.2</version>
         <configuration>
           <configLocation>${maven.multiModuleProjectDirectory}/google_checks.xml</configLocation>
           <violationSeverity>warning</violationSeverity>
@@ -193,7 +193,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.18</version>
+            <version>9.0.1</version>
             <scope>compile</scope>
           </dependency>
         </dependencies>


### PR DESCRIPTION
## Description
Updates dependencies and checkstyle plugin to use latest versions.

Updates the `google_checks.xml` file to accommodate checkstyle changes. Some fields are no longer supported, others were moved to the new `MissingJavadocMethod` module.


## Motivation and Context
There are a couple lingering dependabot PRs and most of the dependencies are test-only, so it made sense to just upgrade everything to latest versions.


## How Has This Been Tested?
Ran `mvn clean install` locally and verified that:
- Checkstyle is running on each module correctly
- All tests pass

Not tested: Checkstyle plugins for IDEs like Eclipse, Intellij, VS Code, etc.
It's possible that these plugins may not be compatible with the latest checkstyle version.

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- non-breaking dependency changes
- breaking checkstyle change

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
