### PR TITLE
Modify recog verify tool to better match Ruby implementation output

### DIFF
--- a/recog/src/main/java/com/rapid7/recog/RecogMatcher.java
+++ b/recog/src/main/java/com/rapid7/recog/RecogMatcher.java
@@ -6,6 +6,8 @@ import com.rapid7.recog.pattern.RecogPatternMatcher;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -114,9 +116,9 @@ public class RecogMatcher implements Serializable {
   public RecogMatcher(RecogPatternMatcher matcher) {
     this.matcher = matcher;
     values = new HashMap<>();
-    positionalParameters = new HashMap<>();
+    positionalParameters = new LinkedHashMap<>();
     namedParameters = new HashSet<>();
-    examples = new HashSet<>();
+    examples = new LinkedHashSet<>();
   }
 
   /**
@@ -259,7 +261,7 @@ public class RecogMatcher implements Serializable {
   }
 
   private void verifyExamplesHaveCaptureGroups(BiConsumer<VerifyStatus, String> consumer) {
-    Map<String, Boolean> captureGroupUsed = new HashMap<>();
+    Map<String, Boolean> captureGroupUsed = new LinkedHashMap<>();
     // get a list of parameters that are defined by capture groups
     for (Entry<String, Integer> parameter : positionalParameters.entrySet()) {
       if (parameter.getValue() > 0 && !parameter.getKey().isEmpty()) {

--- a/recog/src/main/java/com/rapid7/recog/parser/RecogParser.java
+++ b/recog/src/main/java/com/rapid7/recog/parser/RecogParser.java
@@ -171,7 +171,7 @@ public class RecogParser {
         // description (optional)
         NodeList description = fingerprint.getElementsByTagName("description");
         if (description.getLength() > 0)
-          fingerprintPattern.setDescription(description.item(0).getTextContent());
+          fingerprintPattern.setDescription(description.item(0).getTextContent().replaceAll("\\s+", " ").trim());
 
         // example (optional)
         NodeList examples = fingerprint.getElementsByTagName("example");


### PR DESCRIPTION
## Description
Small modifications were made to the recog verify tool to better match the Ruby implementation output. The message order did not match the Ruby implementation since Ruby's hash maintains insertion order. In order to resolve this the following changes were made:
* `HashMap` replaced with `LinkedHashMap`
* `HashSet` replaced with `LinkedHashSet`
* Collapsed consecutive whitespace and trimmed leading and trailing whitespace from the `description` field

## Motivation and Context
This makes it easier to compare output against the Ruby implementation.


## How Has This Been Tested?
* `mvn integration-test`
* Compared the Ruby `recog_verify` output to the `com.rapid7.recog.verify.RecogVerifier` output. Of the 49 XML fingerprint files from rapid7/recog only 3 created differences and those were the result of the Java implementation not currently supporting base64 encoding. The three files with differences were: `ldap_searchresult.xml`, `snmp_sysdescr.xml`, and `telnet_banners.xml`.
```
~/recog $ ./bin/recog_verify xml/*.xml > ruby.txt

~/recog-java $ mvn --projects recog-verify exec:java -Dexec.mainClass="com.rapid7.recog.verify.RecogVerifier" -Dexec.args="$(ls -1 xml/*.xml | xargs)" > java.txt

diff ruby.txt java.txt
```


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
