### PR TITLE
Add support for base64 encoded examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ This library is not yet at a 1:1 parity with the original [rapid7/recog](https:/
 Missing features:
 
 - Matching against multi-line input strings
-- Matching against base64 encoded strings
 - Command line tools like `recog_match`
 
 ## Development

--- a/recog/src/main/java/com/rapid7/recog/FingerprintExample.java
+++ b/recog/src/main/java/com/rapid7/recog/FingerprintExample.java
@@ -1,15 +1,25 @@
 package com.rapid7.recog;
 
+import java.util.Base64;
 import java.util.Map;
+import static java.util.Objects.requireNonNull;
 
 // Represents a fingerprint example and associated data.
 public class FingerprintExample {
+  private static final String ENCODING_KEY = "_encoding";
+
   private final String text;
   private final Map<String, String> attributeMap;
 
   public FingerprintExample(String text, Map<String, String> attributeMap) {
-    this.text = text;
-    this.attributeMap = attributeMap;
+    String tmpText = requireNonNull(text);
+    this.attributeMap = requireNonNull(attributeMap);
+    if (attributeMap.containsKey(ENCODING_KEY) && attributeMap.get(ENCODING_KEY).equals("base64")) {
+      byte[] exampleContentBytes = Base64.getDecoder().decode(tmpText.replaceAll("\\s+", ""));
+      this.text = new String(exampleContentBytes);
+    } else {
+      this.text = text;
+    }
   }
 
   public String getText() {

--- a/recog/src/main/java/com/rapid7/recog/RecogMatcher.java
+++ b/recog/src/main/java/com/rapid7/recog/RecogMatcher.java
@@ -350,7 +350,7 @@ public class RecogMatcher implements Serializable {
    * @return A {@link Pattern} with the compiled flags provided. Will not be {@code null}.
    */
   public static Pattern pattern(String regex, int... flags) {
-    int patternFlags = 0;
+    int patternFlags = Pattern.UNIX_LINES;
     for (int flag : flags)
       patternFlags |= flag;
 

--- a/recog/src/main/java/com/rapid7/recog/parser/RecogParser.java
+++ b/recog/src/main/java/com/rapid7/recog/parser/RecogParser.java
@@ -229,7 +229,7 @@ public class RecogParser {
   /////////////////////////////////////////////////////////////////////////
 
   private int parseFlags(String flags) {
-    int cflags = 0;
+    int cflags = Pattern.UNIX_LINES;
     if (flags != null && flags.length() != 0) {
       StringTokenizer tok = new StringTokenizer(flags, "|,; \t");
       while (tok.hasMoreTokens()) {
@@ -239,9 +239,8 @@ public class RecogParser {
             cflags |= Pattern.CASE_INSENSITIVE;
             break;
           case "REG_DOT_NEWLINE":
-            cflags |= Pattern.DOTALL;
-            break;
           case "REG_MULTILINE":
+            cflags |= Pattern.DOTALL;
             cflags |= Pattern.MULTILINE;
             break;
           default:

--- a/recog/src/main/java/com/rapid7/recog/parser/RecogParser.java
+++ b/recog/src/main/java/com/rapid7/recog/parser/RecogParser.java
@@ -177,23 +177,18 @@ public class RecogParser {
         NodeList examples = fingerprint.getElementsByTagName("example");
         for (int examplesIndex = 0; examplesIndex < examples.getLength(); examplesIndex++) {
           Element example = (Element) examples.item(examplesIndex);
-          String exampleContent = example.getTextContent();
 
-          if ("base64".equals(example.getAttribute("_encoding"))) {
-            // TODO: these are currently ignored as the Base64 decoding isn't working properly
-          } else {
-            HashMap<String, String> attributeMap = new HashMap<>();
-            NamedNodeMap exAttributes = example.getAttributes();
+          HashMap<String, String> attributeMap = new HashMap<>();
+          NamedNodeMap exAttributes = example.getAttributes();
 
-            for (int i = 0; i < exAttributes.getLength(); i++) {
-              Node attr = exAttributes.item(i);
-              String attrName = attr.getNodeName();
-              String attrValue = attr.getNodeValue();
-              attributeMap.put(attrName, attrValue);
-            }
-
-            fingerprintPattern.addExample(new FingerprintExample(exampleContent, attributeMap));
+          for (int i = 0; i < exAttributes.getLength(); i++) {
+            Node attr = exAttributes.item(i);
+            String attrName = attr.getNodeName();
+            String attrValue = attr.getNodeValue();
+            attributeMap.put(attrName, attrValue);
           }
+
+          fingerprintPattern.addExample(new FingerprintExample(example.getTextContent(), attributeMap));
         }
 
         // parse and add parameter specifications

--- a/recog/src/test/java/com/rapid7/recog/parser/FingerprintMatcherParserTest.java
+++ b/recog/src/test/java/com/rapid7/recog/parser/FingerprintMatcherParserTest.java
@@ -94,7 +94,7 @@ public class FingerprintMatcherParserTest {
     assertThat(patterns.size(), is(2));
     assertThat(patterns, hasItems(
             new RecogMatcher(pattern("^Apache/\\d$", CASE_INSENSITIVE)).addValue("service.vendor", "Apache").addValue("service.product", "HTTPD").addValue("service.family", "Apache"),
-            new RecogMatcher(pattern("^Apache$", MULTILINE)).addValue("service.vendor", "Apache").addValue("service.product", "HTTPD").addValue("service.family", "Apache")));
+            new RecogMatcher(pattern("^Apache$", DOTALL, MULTILINE)).addValue("service.vendor", "Apache").addValue("service.product", "HTTPD").addValue("service.family", "Apache")));
   }
 
   @Test


### PR DESCRIPTION
## Description
Adds support for base64 encoded examples.


## Motivation and Context
Increases feature parity with other recog language implementations.


## How Has This Been Tested?
* `mvn clean install -DskipITs`
* `mvn integration-test` - this will fail until the `xml/telnet_banners.xml` changes are landed in rapid7/recog and available via Ruby Gems
* The `com.rapid7.recog.verify.RecogVerifier` tool no longer reports failures in any of the 49 XML fingerprint files from the modified rapid7/recog branch.
  ```
  mvn --projects recog-verify exec:java -Dexec.mainClass="com.rapid7.recog.verify.RecogVerifier" -Dexec.args="$(ls -1 xml/*.xml | xargs)"
  ```


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
