### PR TITLE
Add support for external example files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
 
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
+        <artifactId>mockito-inline</artifactId>
         <version>${mockito.version}</version>
         <scope>test</scope>
       </dependency>

--- a/recog-verify/pom.xml
+++ b/recog-verify/pom.xml
@@ -66,7 +66,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <artifactId>mockito-inline</artifactId>
     </dependency>
 
     <dependency>

--- a/recog-verify/src/main/java/com/rapid7/recog/verify/RecogVerifier.java
+++ b/recog-verify/src/main/java/com/rapid7/recog/verify/RecogVerifier.java
@@ -138,7 +138,8 @@ public class RecogVerifier {
           failures += verifier.getReporter().getFailureCount();
           warnings += verifier.getReporter().getWarningCount();
         } catch (ParseException exception) {
-          System.err.printf("error: parsing fingerprints file '%s': %s%n", p.toFile(), exception.getMessage());
+          String message = exception.getCause() != null ? exception.getCause().getMessage() : exception.getMessage();
+          System.err.printf("error: parsing fingerprints file '%s': %s%n", p.toFile(), message);
           System.exit(-1);
         }
       }

--- a/recog/pom.xml
+++ b/recog/pom.xml
@@ -48,7 +48,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <artifactId>mockito-inline</artifactId>
     </dependency>
 
     <dependency>

--- a/recog/src/main/java/com/rapid7/recog/RecogMatcher.java
+++ b/recog/src/main/java/com/rapid7/recog/RecogMatcher.java
@@ -243,7 +243,7 @@ public class RecogMatcher implements Serializable {
       for (Map.Entry<String, String> entry : example.getAttributeMap().entrySet()) {
         String key = entry.getKey();
         String value = entry.getValue();
-        if (key.equals("_encoding")) {
+        if (key.equals("_encoding") || key.equals("_filename")) {
           continue;
         }
 


### PR DESCRIPTION
## Description
Adds support for external example files.


## Motivation and Context
Increases feature parity with other recog language implementations. rapid7/recog#382 introduced this feature into the Ruby language implementation.


## How Has This Been Tested?
* New unit tests
* `mvn clean install -DskipITs`
* `mvn integration-test` - this will fail until the `xml/telnet_banners.xml` changes are landed in rapid7/recog and available via Ruby Gems
* The `com.rapid7.recog.verify.RecogVerifier` tool with local fingerprints using external example files. These fingerprints included a subset from `xml/ldap_searchresult.xml` where the base64 example data was decoded into external example files.

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
