### PR TITLE
Sync with recog/#402: Reduce warning output when no tests are present

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   </distributionManagement>
 
   <properties>
-    <r7.recog.content.version>2.3.21</r7.recog.content.version>
+    <r7.recog.content.version>2.3.22</r7.recog.content.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/recog-verify/src/test/java/com/rapid7/recog/verify/RecogVerifierTest.java
+++ b/recog-verify/src/test/java/com/rapid7/recog/verify/RecogVerifierTest.java
@@ -83,7 +83,7 @@ public class RecogVerifierTest {
     // then
     assertEquals(0, verifier.getReporter().getSuccessCount());
     assertEquals(0, verifier.getReporter().getFailureCount());
-    assertEquals(4, verifier.getReporter().getWarningCount());
+    assertEquals(1, verifier.getReporter().getWarningCount());
   }
 
   @Test

--- a/recog/src/main/java/com/rapid7/recog/RecogMatcher.java
+++ b/recog/src/main/java/com/rapid7/recog/RecogMatcher.java
@@ -225,6 +225,7 @@ public class RecogMatcher implements Serializable {
     // look for the presence of test cases
     if (examples.size() == 0) {
       consumer.accept(VerifyStatus.Warn, String.format("'%s' has no test cases", description));
+      return;
     }
 
     // make sure each test case passes


### PR DESCRIPTION
## Description
See rapid7/recog#402. Eliminates spurious warnings.


## Motivation and Context
Reduces warning, see above linked issue to recog-ruby.

## How Has This Been Tested?
Ran "mvn clean install" which runs tests & integration tests.

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
