### PR TITLE
Enhance recog verify to report an untested parameter as a failure

### DIFF
--- a/recog-verify/src/test/java/com/rapid7/recog/verify/RecogVerifierTest.java
+++ b/recog-verify/src/test/java/com/rapid7/recog/verify/RecogVerifierTest.java
@@ -87,35 +87,6 @@ public class RecogVerifierTest {
   }
 
   @Test
-  public void verifySuccessfulExampleNonZeroPositionParamsWarnCount() throws ParseException {
-    // given
-    String xml = "<?xml version=\"1.0\"?>\n"
-        + "<fingerprints matches=\"recog-verifier-test\">\n"
-        + "    <fingerprint pattern=\"^(\\w+) Server ([0-9.]+) - ([0-9]+)$\">\n"
-        + "        <description>Service Server - no examples or params</description>\n"
-        + "        <example>Media Server 7.9.3 - 1631723269</example>\n"
-        + "        <param pos=\"0\" name=\"service.vendor\" value=\"VendorName\"/>\n"
-        + "        <param pos=\"0\" name=\"service.product\" value=\"ProductName\"/>\n"
-        + "        <param pos=\"1\" name=\"service.name\"/>\n"
-        + "        <param pos=\"2\" name=\"service.version\"/>"
-        + "        <param pos=\"3\" name=\"service.version-date\"/>"
-        + "    </fingerprint>\n"
-        + "</fingerprints>";
-
-    // when
-    RecogParser recogParser = new RecogParser(true);
-    RecogMatchers matchers = recogParser.parse(new StringReader(xml), anyString());
-    VerifierOptions verifierOpts = new VerifierOptions();
-    RecogVerifier verifier = RecogVerifier.create(verifierOpts, matchers, NullOutputStream.NULL_OUTPUT_STREAM);
-    verifier.verify();
-
-    // then
-    assertEquals(1, verifier.getReporter().getSuccessCount());
-    assertEquals(0, verifier.getReporter().getFailureCount());
-    assertEquals(3, verifier.getReporter().getWarningCount());
-  }
-
-  @Test
   public void verifySuccessfulExample() throws ParseException {
     // given
     String xml = "<?xml version=\"1.0\"?>\n"
@@ -171,6 +142,35 @@ public class RecogVerifierTest {
     // then
     assertEquals(1, verifier.getReporter().getSuccessCount());
     assertEquals(1, verifier.getReporter().getFailureCount());
+    assertEquals(0, verifier.getReporter().getWarningCount());
+  }
+
+  @Test
+  public void verifySuccessfulExampleUntestedParamsFailCount() throws ParseException {
+    // given
+    String xml = "<?xml version=\"1.0\"?>\n"
+        + "<fingerprints matches=\"recog-verifier-test\">\n"
+        + "    <fingerprint pattern=\"^(\\w+) Server ([0-9.]+) - ([0-9]+)$\">\n"
+        + "        <description>Service Server - no examples or params</description>\n"
+        + "        <example>Media Server 7.9.3 - 1631723269</example>\n"
+        + "        <param pos=\"0\" name=\"service.vendor\" value=\"VendorName\"/>\n"
+        + "        <param pos=\"0\" name=\"service.product\" value=\"ProductName\"/>\n"
+        + "        <param pos=\"1\" name=\"service.name\"/>\n"
+        + "        <param pos=\"2\" name=\"service.version\"/>"
+        + "        <param pos=\"3\" name=\"service.version-date\"/>"
+        + "    </fingerprint>\n"
+        + "</fingerprints>";
+
+    // when
+    RecogParser recogParser = new RecogParser(true);
+    RecogMatchers matchers = recogParser.parse(new StringReader(xml), anyString());
+    VerifierOptions verifierOpts = new VerifierOptions();
+    RecogVerifier verifier = RecogVerifier.create(verifierOpts, matchers, NullOutputStream.NULL_OUTPUT_STREAM);
+    verifier.verify();
+
+    // then
+    assertEquals(1, verifier.getReporter().getSuccessCount());
+    assertEquals(3, verifier.getReporter().getFailureCount());
     assertEquals(0, verifier.getReporter().getWarningCount());
   }
 

--- a/recog/src/main/java/com/rapid7/recog/RecogMatcher.java
+++ b/recog/src/main/java/com/rapid7/recog/RecogMatcher.java
@@ -287,7 +287,7 @@ public class RecogMatcher implements Serializable {
       Boolean paramUsed = entry.getValue();
       if (!paramUsed) {
         String message = String.format("'%s' is missing an example that checks for parameter '%s' which is derived from a capture group", description, paramName);
-        consumer.accept(VerifyStatus.Warn, message);
+        consumer.accept(VerifyStatus.Fail, message);
       }
     }
   }


### PR DESCRIPTION
## Description
Enhances `com.rapid7.recog.verify.RecogVerifier` to report an untested parameter as a failure instead of a warning. This creates feature parity with changes introduced in rapid7/recog#405.



## Motivation and Context
Ensure all fingerprints have examples that fully verify all capture group parameters.


## How Has This Been Tested?
* `mvn clean install`
* Manually compared output from rapid7/recog `bin/recog_verify` tool with output from `com.rapid7.recog.verify.RecogVerifier`
```
mvn --projects recog-verify exec:java -Dexec.mainClass="com.rapid7.recog.verify.RecogVerifier" -Dexec.args="$(ls -1 xml/*.xml | xargs)"
```


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
