### PR TITLE
Disable recog-parent and build-tools deploy

### DIFF
--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -8,4 +8,8 @@
   <artifactId>build-tools</artifactId>
   <version>0.8.0-SNAPSHOT</version>
   <description>Maven plugins build tools</description>
+
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,8 @@
     <r7.recog.content.version>2.3.23</r7.recog.content.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <!-- Skip deploy of recog-parent -->
+    <maven.deploy.skip>true</maven.deploy.skip>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- third party dependencies -->
     <commons.cli.version>1.4</commons.cli.version>

--- a/recog-verify/pom.xml
+++ b/recog-verify/pom.xml
@@ -16,6 +16,10 @@
     <version>0.8.0-SNAPSHOT</version>
   </parent>
 
+  <properties>
+    <maven.deploy.skip>false</maven.deploy.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.rapid7.recog</groupId>

--- a/recog/pom.xml
+++ b/recog/pom.xml
@@ -15,6 +15,10 @@
     <version>0.8.0-SNAPSHOT</version>
   </parent>
 
+  <properties>
+    <maven.deploy.skip>false</maven.deploy.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
## Description
Disables deploy for `recog-parent` and `build-tools` modules.


## Motivation and Context
To allow jenkins to produce a successful build.


## How Has This Been Tested?
* Modified `distributionManagement` block in root `pom.xml`
```
diff --git a/pom.xml b/pom.xml
index fe74d0b..9753067 100644
--- a/pom.xml
+++ b/pom.xml
@@ -31,14 +31,14 @@
   </licenses>

   <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
     <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <id>local-release</id>
+      <url>file:../local_repo/release</url>
     </repository>
+    <snapshotRepository>
+      <id>local-snapshot</id>
+      <url>file:../local_repo/snapshot</url>
+    </snapshotRepository>
   </distributionManagement>
```
* Ran most of the goal executed in the job: `mvn deploy -B -C -U -Dprod`
* Confirmed command ran without errors and that the `recog-java` and `recog-verify` modules were deployed to the local directory specified in the modified `distributionManagement` block

## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
