### PR TITLE
Use UTF8 string rather than any random string in tests

### DIFF
--- a/recog-verify/src/test/java/com/rapid7/recog/verify/RecogVerifierTest.java
+++ b/recog-verify/src/test/java/com/rapid7/recog/verify/RecogVerifierTest.java
@@ -6,7 +6,7 @@ import com.rapid7.recog.parser.RecogParser;
 import java.io.StringReader;
 import org.apache.commons.io.output.NullOutputStream;
 import org.junit.jupiter.api.Test;
-import static com.rapid7.recog.TestGenerators.anyString;
+import static com.rapid7.recog.TestGenerators.anyUTF8String;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RecogVerifierTest {
@@ -22,7 +22,7 @@ public class RecogVerifierTest {
 
     // when
     RecogParser recogParser = new RecogParser(true);
-    RecogMatchers matchers = recogParser.parse(new StringReader(xml), anyString());
+    RecogMatchers matchers = recogParser.parse(new StringReader(xml), anyUTF8String());
     VerifierOptions verifierOpts = new VerifierOptions();
     RecogVerifier verifier = RecogVerifier.create(verifierOpts, matchers, NullOutputStream.NULL_OUTPUT_STREAM);
     verifier.verify();
@@ -47,7 +47,7 @@ public class RecogVerifierTest {
 
     // when
     RecogParser recogParser = new RecogParser(true);
-    RecogMatchers matchers = recogParser.parse(new StringReader(xml), anyString());
+    RecogMatchers matchers = recogParser.parse(new StringReader(xml), anyUTF8String());
     VerifierOptions verifierOpts = new VerifierOptions();
     RecogVerifier verifier = RecogVerifier.create(verifierOpts, matchers, NullOutputStream.NULL_OUTPUT_STREAM);
     verifier.verify();
@@ -75,7 +75,7 @@ public class RecogVerifierTest {
 
     // when
     RecogParser recogParser = new RecogParser(true);
-    RecogMatchers matchers = recogParser.parse(new StringReader(xml), anyString());
+    RecogMatchers matchers = recogParser.parse(new StringReader(xml), anyUTF8String());
     VerifierOptions verifierOpts = new VerifierOptions();
     RecogVerifier verifier = RecogVerifier.create(verifierOpts, matchers, NullOutputStream.NULL_OUTPUT_STREAM);
     verifier.verify();
@@ -104,7 +104,7 @@ public class RecogVerifierTest {
 
     // when
     RecogParser recogParser = new RecogParser(true);
-    RecogMatchers matchers = recogParser.parse(new StringReader(xml), anyString());
+    RecogMatchers matchers = recogParser.parse(new StringReader(xml), anyUTF8String());
     VerifierOptions verifierOpts = new VerifierOptions();
     RecogVerifier verifier = RecogVerifier.create(verifierOpts, matchers, NullOutputStream.NULL_OUTPUT_STREAM);
     verifier.verify();
@@ -134,7 +134,7 @@ public class RecogVerifierTest {
 
     // when
     RecogParser recogParser = new RecogParser(true);
-    RecogMatchers matchers = recogParser.parse(new StringReader(xml), anyString());
+    RecogMatchers matchers = recogParser.parse(new StringReader(xml), anyUTF8String());
     VerifierOptions verifierOpts = new VerifierOptions();
     RecogVerifier verifier = RecogVerifier.create(verifierOpts, matchers, NullOutputStream.NULL_OUTPUT_STREAM);
     verifier.verify();
@@ -163,7 +163,7 @@ public class RecogVerifierTest {
 
     // when
     RecogParser recogParser = new RecogParser(true);
-    RecogMatchers matchers = recogParser.parse(new StringReader(xml), anyString());
+    RecogMatchers matchers = recogParser.parse(new StringReader(xml), anyUTF8String());
     VerifierOptions verifierOpts = new VerifierOptions();
     RecogVerifier verifier = RecogVerifier.create(verifierOpts, matchers, NullOutputStream.NULL_OUTPUT_STREAM);
     verifier.verify();
@@ -193,7 +193,7 @@ public class RecogVerifierTest {
 
     // when
     RecogParser recogParser = new RecogParser(true);
-    RecogMatchers matchers = recogParser.parse(new StringReader(xml), anyString());
+    RecogMatchers matchers = recogParser.parse(new StringReader(xml), anyUTF8String());
     VerifierOptions verifierOpts = new VerifierOptions();
     RecogVerifier verifier = RecogVerifier.create(verifierOpts, matchers, NullOutputStream.NULL_OUTPUT_STREAM);
     verifier.verify();

--- a/recog/src/test/java/com/rapid7/recog/FingerprintMatcherTest.java
+++ b/recog/src/test/java/com/rapid7/recog/FingerprintMatcherTest.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import static com.rapid7.recog.RecogMatcher.pattern;
-import static com.rapid7.recog.TestGenerators.anyString;
+import static com.rapid7.recog.TestGenerators.anyUTF8String;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.commons.lang3.RandomUtils.nextInt;
@@ -25,12 +25,12 @@ public class FingerprintMatcherTest {
 
   @Test
   public void valueNameMustNotBeNull() {
-    assertThrows(NullPointerException.class, () -> new RecogMatcher(anyPattern()).addValue(null, anyString()));
+    assertThrows(NullPointerException.class, () -> new RecogMatcher(anyPattern()).addValue(null, anyUTF8String()));
   }
 
   @Test
   public void parameterPositionMustBeGreaterThanZero() {
-    assertThrows(IllegalArgumentException.class, () -> new RecogMatcher(anyPattern()).addParam(nextInt(Integer.MIN_VALUE, 0), anyString()));
+    assertThrows(IllegalArgumentException.class, () -> new RecogMatcher(anyPattern()).addParam(nextInt(Integer.MIN_VALUE, 0), anyUTF8String()));
   }
 
   @Test

--- a/recog/src/test/java/com/rapid7/recog/FingerprintMatchersTest.java
+++ b/recog/src/test/java/com/rapid7/recog/FingerprintMatchersTest.java
@@ -5,7 +5,7 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import static com.rapid7.recog.RecogMatcher.pattern;
-import static com.rapid7.recog.TestGenerators.anyString;
+import static com.rapid7.recog.TestGenerators.anyUTF8String;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -31,7 +31,7 @@ public class FingerprintMatchersTest {
   @Test
   public void matchesNoMatchers() {
     // given
-    String fingerprint = anyString();
+    String fingerprint = anyUTF8String();
     RecogMatchers matchers = new RecogMatchers();
 
     // when
@@ -44,7 +44,7 @@ public class FingerprintMatchersTest {
   @Test
   public void matchesNoMatches() {
     // given
-    String fingerprint = anyString();
+    String fingerprint = anyUTF8String();
     RecogMatchers matchers = new RecogMatchers();
     matchers.add(new RecogMatcher(pattern("foo")));
     matchers.add(new RecogMatcher(pattern("bar")));

--- a/recog/src/test/java/com/rapid7/recog/TestGenerators.java
+++ b/recog/src/test/java/com/rapid7/recog/TestGenerators.java
@@ -7,8 +7,11 @@ public class TestGenerators {
   
   private static Random random = new Random();
 
-  public static String anyString() {
-    return RandomStringUtils.random(16);
+  public static String anyUTF8String() {
+    return anyUTF8String(16);
+  }
+  public static String anyUTF8String(int length) {
+    return RandomStringUtils.random(length, 0, 0x10ffff, true, true);
   }
 
   public static <E extends Enum<E>> E anyEnum(Class<E> enumType) {

--- a/recog/src/test/java/com/rapid7/recog/parser/FingerprintMatcherParserTest.java
+++ b/recog/src/test/java/com/rapid7/recog/parser/FingerprintMatcherParserTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import static com.rapid7.recog.RecogMatcher.pattern;
-import static com.rapid7.recog.TestGenerators.anyString;
+import static com.rapid7.recog.TestGenerators.anyUTF8String;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 import static java.util.regex.Pattern.DOTALL;
 import static java.util.regex.Pattern.MULTILINE;
@@ -34,7 +34,7 @@ public class FingerprintMatcherParserTest {
     String xml = "<?xml version=\"1.0\"?><fingerprints/>";
 
     // when
-    RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyString());
+    RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyUTF8String());
 
     // then
     assertThat(patterns.size(), is(0));
@@ -46,7 +46,7 @@ public class FingerprintMatcherParserTest {
     String xml = "<?xml version=\"1.0\"?>foo";
 
     // when
-    assertThrows(ParseException.class, () -> new RecogParser().parse(new StringReader(xml), anyString()));
+    assertThrows(ParseException.class, () -> new RecogParser().parse(new StringReader(xml), anyUTF8String()));
 
     // then - throws exception
   }
@@ -68,7 +68,7 @@ public class FingerprintMatcherParserTest {
             + "</fingerprints>";
 
     // when
-    RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyString());
+    RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyUTF8String());
 
     // then
     assertThat(patterns.size(), is(1));
@@ -99,7 +99,7 @@ public class FingerprintMatcherParserTest {
             + "</fingerprints>";
 
     // when
-    RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyString());
+    RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyUTF8String());
 
     // then
     assertThat(patterns.size(), is(2));
@@ -127,7 +127,7 @@ public class FingerprintMatcherParserTest {
         + "</fingerprints>", exServiceVersion, exBase64);
 
     // when
-    RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyString());
+    RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyUTF8String());
 
     // then
     assertThat(patterns.size(), is(1));
@@ -141,7 +141,7 @@ public class FingerprintMatcherParserTest {
     // given
     int exServiceVersion = 1;
     String exText = String.format("Apache %d", exServiceVersion);
-    String exFilename = anyString();
+    String exFilename = anyUTF8String();
     String xml = String.format("<?xml version=\"1.0\"?>\n"
         + "<fingerprints matches=\"http_header.server\">"
         + "    <fingerprint pattern=\"^Apache (\\d)$\">\n"
@@ -159,7 +159,7 @@ public class FingerprintMatcherParserTest {
           .thenReturn(exText.getBytes(StandardCharsets.US_ASCII));
 
       // when
-      RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyString());
+      RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyUTF8String());
 
       // then
       assertThat(patterns.size(), is(1));
@@ -199,7 +199,7 @@ public class FingerprintMatcherParserTest {
             + "</fingerprints>";
 
     // when
-    RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyString());
+    RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyUTF8String());
 
     // then
     assertThat(patterns.size(), is(2));
@@ -222,7 +222,7 @@ public class FingerprintMatcherParserTest {
             + "</fingerprints>";
 
     // when
-    RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyString());
+    RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyUTF8String());
 
     // then
     assertThat(patterns.size(), is(0));
@@ -245,7 +245,7 @@ public class FingerprintMatcherParserTest {
             + "</fingerprints>";
 
     // when
-    RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyString());
+    RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyUTF8String());
 
     // then
     assertThat(patterns.size(), is(0));
@@ -268,7 +268,7 @@ public class FingerprintMatcherParserTest {
             + "</fingerprints>";
 
     // when
-    RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyString());
+    RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyUTF8String());
 
     // then
     assertThat(patterns.size(), is(1));
@@ -292,7 +292,7 @@ public class FingerprintMatcherParserTest {
             + "</fingerprints>";
 
     // when
-    RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyString());
+    RecogMatchers patterns = new RecogParser().parse(new StringReader(xml), anyUTF8String());
 
     // then
     assertThat(patterns.size(), is(1));
@@ -318,7 +318,7 @@ public class FingerprintMatcherParserTest {
 
     // when
     Exception exception = assertThrows(ParseException.class, () -> {
-      new RecogParser(true).parse(new StringReader(xml), anyString());
+      new RecogParser(true).parse(new StringReader(xml), anyUTF8String());
     }, expectedMessage);
 
     // then
@@ -346,7 +346,7 @@ public class FingerprintMatcherParserTest {
 
     // when
     Exception exception = assertThrows(ParseException.class, () -> {
-      new RecogParser(true).parse(new StringReader(xml), anyString());
+      new RecogParser(true).parse(new StringReader(xml), anyUTF8String());
     }, expectedMessage);
 
     // then
@@ -375,7 +375,7 @@ public class FingerprintMatcherParserTest {
 
     // when
     Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-      new RecogParser(true).parse(new StringReader(xml), anyString());
+      new RecogParser(true).parse(new StringReader(xml), anyUTF8String());
     });
 
     // then
@@ -385,7 +385,7 @@ public class FingerprintMatcherParserTest {
   @Test
   public void missingExternalExampleFileFailsWhenStrict() {
     // given
-    String exFilename = anyString();
+    String exFilename = anyUTF8String();
     String xml = String.format("<?xml version=\"1.0\"?>\n"
         + "<fingerprints matches=\"http_header.server\">"
         + "    <fingerprint pattern=\"^Apache (\\d)$\">\n"
@@ -397,7 +397,7 @@ public class FingerprintMatcherParserTest {
         + "        <param pos=\"1\" name=\"service.version\"/>\n"
         + "    </fingerprint>\n"
         + "</fingerprints>", exFilename);
-    String name = anyString();
+    String name = anyUTF8String();
     String expectedMessage = String.format("Unable to process fingerprint example file '%s'", Paths.get(name, exFilename));
 
     // when

--- a/recog/src/test/java/com/rapid7/recog/provider/CompositeFingerprintMatchersProviderTest.java
+++ b/recog/src/test/java/com/rapid7/recog/provider/CompositeFingerprintMatchersProviderTest.java
@@ -5,7 +5,7 @@ import com.rapid7.recog.RecogMatchers;
 import com.rapid7.recog.RecogType;
 import org.junit.jupiter.api.Test;
 import static com.rapid7.recog.TestGenerators.anyEnum;
-import static com.rapid7.recog.TestGenerators.anyString;
+import static com.rapid7.recog.TestGenerators.anyUTF8String;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -18,7 +18,7 @@ public class CompositeFingerprintMatchersProviderTest {
   @Test
   public void getMatchersNoProviders() {
     // given
-    String name = anyString();
+    String name = anyUTF8String();
     RecogType type = anyEnum(RecogType.class);
     CompositeRecogMatchersProvider provider = new CompositeRecogMatchersProvider();
 
@@ -32,7 +32,7 @@ public class CompositeFingerprintMatchersProviderTest {
   @Test
   public void getMatchersSingleProviderNoMatch() {
     // given
-    String name = anyString();
+    String name = anyUTF8String();
     RecogType type = anyEnum(RecogType.class);
     IRecogMatchersProvider provider = mock(IRecogMatchersProvider.class);
     given(provider.getMatchers(name, type)).willReturn(null);
@@ -48,7 +48,7 @@ public class CompositeFingerprintMatchersProviderTest {
   @Test
   public void getMatchersSingleProviderMatch() {
     // given
-    String name = anyString();
+    String name = anyUTF8String();
     RecogType type = anyEnum(RecogType.class);
     IRecogMatchersProvider provider = mock(IRecogMatchersProvider.class);
     RecogMatchers result = mock(RecogMatchers.class);
@@ -65,7 +65,7 @@ public class CompositeFingerprintMatchersProviderTest {
   @Test
   public void getMatchersMultipleProviderNoMatch() {
     // given
-    String name = anyString();
+    String name = anyUTF8String();
     RecogType type = anyEnum(RecogType.class);
     IRecogMatchersProvider provider1 = mock(IRecogMatchersProvider.class);
     IRecogMatchersProvider provider2 = mock(IRecogMatchersProvider.class);
@@ -85,7 +85,7 @@ public class CompositeFingerprintMatchersProviderTest {
   @Test
   public void getMatchersMultipleProviderSingleMatchFirst() {
     // given
-    String name = anyString();
+    String name = anyUTF8String();
     RecogType type = anyEnum(RecogType.class);
     IRecogMatchersProvider provider1 = mock(IRecogMatchersProvider.class);
     IRecogMatchersProvider provider2 = mock(IRecogMatchersProvider.class);
@@ -106,7 +106,7 @@ public class CompositeFingerprintMatchersProviderTest {
   @Test
   public void getMatchersMultipleProviderSingleMatchLast() {
     // given
-    String name = anyString();
+    String name = anyUTF8String();
     RecogType type = anyEnum(RecogType.class);
     IRecogMatchersProvider provider1 = mock(IRecogMatchersProvider.class);
     IRecogMatchersProvider provider2 = mock(IRecogMatchersProvider.class);
@@ -127,7 +127,7 @@ public class CompositeFingerprintMatchersProviderTest {
   @Test
   public void getMatchersMultipleProviderMultipleMatchesFirstIsReturned() {
     // given
-    String name = anyString();
+    String name = anyUTF8String();
     RecogType type = anyEnum(RecogType.class);
     IRecogMatchersProvider provider1 = mock(IRecogMatchersProvider.class);
     IRecogMatchersProvider provider2 = mock(IRecogMatchersProvider.class);
@@ -156,7 +156,7 @@ public class CompositeFingerprintMatchersProviderTest {
   @Test
   public void getMatchersMultipleProviderMultipleMatchesFirstIsReturnedWhenNotFirst() {
     // given
-    String name = anyString();
+    String name = anyUTF8String();
     RecogType type = anyEnum(RecogType.class);
     IRecogMatchersProvider provider1 = mock(IRecogMatchersProvider.class);
     IRecogMatchersProvider provider2 = mock(IRecogMatchersProvider.class);


### PR DESCRIPTION
## Description
Changes `TestGenerators.anyString` to `TestGenerators.anyUTF8String` to create a random UTF8 string rather than any random string data. The tests run without issue locally, but are failing on the jenkins build server.


## Motivation and Context
To allow jenkins to produce a successful build.


## How Has This Been Tested?
* `mvn clean install`


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
