### PR TITLE
Correct SCM tag after 0.8.1 build issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <connection>scm:git:git@github.com:rapid7/recog-java.git</connection>
     <developerConnection>scm:git:git@github.com:rapid7/recog-java.git</developerConnection>
     <url>https://github.com/rapid7/recog-java</url>
-    <tag>recog-parent-0.8.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <developers>


### PR DESCRIPTION
## Description
The release build for `0.8.1` encountered issues and between Jenkin's commit abdc7463b6cbbbd0badb4f2bcb0c2f62b55fee07 and #26 not changing the SCM tag value it was not restored to `HEAD` in Jenkin's commit https://github.com/rapid7/recog-java/commit/54fec37d088a5335c63d9a8e7b53000bc4a072c1. This PR corrects the SCM tag by restoring to `HEAD` in order to prepare for next development iteration.


## Motivation and Context
Avoid any possible issues with future builds.


## How Has This Been Tested?
* `mvn clean install`, however, this doesn't test the change.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
