### PR TITLE
Modify RecogMatchersProvider to use recursive walk

### DIFF
--- a/recog/src/main/java/com/rapid7/recog/provider/RecogMatchersProvider.java
+++ b/recog/src/main/java/com/rapid7/recog/provider/RecogMatchersProvider.java
@@ -106,7 +106,7 @@ public class RecogMatchersProvider implements IRecogMatchersProvider, Serializab
    */
   private void parseFromWalkablePath(Path path) {
     final PathMatcher filter = path.getFileSystem().getPathMatcher("glob:**/*.xml");
-    try (Stream<Path> files = Files.list(path)) {
+    try (Stream<Path> files = Files.walk(path)) {
       files.filter(filter::matches).forEach(file -> {
         try {
           final String fileName = file.getFileName().toString();


### PR DESCRIPTION
## Description
Modifies `RecogMatchersProvider.parseFromWalkablePath` to use recursive walk rather than the non-recursive list.


## Motivation and Context
Restoring this aspect of the method's previous behavior.


## How Has This Been Tested?
* `mvn clean install`


## Types of changes
- Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
