### PR TITLE
Bump recog content to version 3.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
   </distributionManagement>
 
   <properties>
-    <r7.recog.content.version>2.3.23</r7.recog.content.version>
+    <r7.recog.content.version>3.0.3</r7.recog.content.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/recog/pom.xml
+++ b/recog/pom.xml
@@ -110,15 +110,33 @@
             <phase>pre-integration-test</phase>
             <configuration>
               <target>
+                <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath"/>
                 <mkdir dir="${project.build.directory}/recog" />
-                <get src="http://production.cf.rubygems.org/gems/recog-${r7.recog.content.version}.gem" dest="${project.build.directory}/recog/recog-${r7.recog.content.version}.tar" usetimestamp="true" />
-                <untar src="${project.build.directory}/recog/recog-${r7.recog.content.version}.tar" dest="${project.build.directory}/recog" />
-                <untar compression="gzip" src="${project.build.directory}/recog/data.tar.gz" dest="${project.build.directory}/test-classes/com/rapid7/recog/fingerprints">
+                <get dest="${project.build.directory}/recog/recog-${r7.recog.content.version}.tar" src="http://production.cf.rubygems.org/gems/recog-${r7.recog.content.version}.gem" usetimestamp="true"/>
+
+                <!-- Extract the recog gem archive. -->
+                <untar dest="${project.build.directory}/recog" src="${project.build.directory}/recog/recog-${r7.recog.content.version}.tar"/>
+
+                <!-- Get the appropriate fingerprint data glob based on the recog version. -->
+                <propertyregex property="recog.version.major"
+                               input="${r7.recog.content.version}"
+                               regexp="^(\d+)\.(\d+)\.(\d+).*$"
+                               select="\1"/>
+                <condition property="fingerprint-data-glob" value="xml/*.xml" else="recog/xml/*.xml">
+                  <or>
+                    <equals arg1="${recog.version.major}" arg2="2"/>
+                    <equals arg1="${recog.version.major}" arg2="1"/>
+                  </or>
+                </condition>
+
+                <!-- Extract the XML data from recog. -->
+                <untar compression="gzip" dest="${project.build.directory}/test-classes/com/rapid7/recog/fingerprints" src="${project.build.directory}/recog/data.tar.gz">
                   <patternset>
-                    <include name="xml/*.xml" />
+                    <include name="${fingerprint-data-glob}"/>
                   </patternset>
-                  <mapper type="flatten" />
+                  <mapper type="flatten"/>
                 </untar>
+
               </target>
             </configuration>
             <goals>
@@ -126,6 +144,19 @@
             </goals>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>ant-contrib</groupId>
+            <artifactId>ant-contrib</artifactId>
+            <version>1.0b3</version>
+            <exclusions>
+              <exclusion>
+                <groupId>ant</groupId>
+                <artifactId>ant</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/recog/pom.xml
+++ b/recog/pom.xml
@@ -103,7 +103,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.7</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>recog-download</id>


### PR DESCRIPTION
## Description
Bumps the recog content to version [3.0.3](https://rubygems.org/gems/recog/versions/3.0.3), `maven-antrun-plugin` to version to 3.1.0, and enhances `recog-download` (pre-integration-test phase) to support both the old and new recog gem structure. The configuration of `recog-download` to use `ant-contrib` follows from the `maven-antrun-plugin` documentation [example](https://maven.apache.org/plugins/maven-antrun-plugin/examples/customTasks.html).


## Motivation and Context
Update to the latest available recog version.


## How Has This Been Tested?
* `mvn clean integration-test`
* `mvn clean install`


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [x] I have updated the documentation accordingly (or changes are not required).
- [x] I have added tests to cover my changes (or new tests are not required).
- [x] All new and existing tests passed.
