### PR TITLE
Add null check to filepath before getting name

### DIFF
--- a/recog/src/main/java/com/rapid7/recog/provider/RecogMatchersProvider.java
+++ b/recog/src/main/java/com/rapid7/recog/provider/RecogMatchersProvider.java
@@ -110,8 +110,7 @@ public class RecogMatchersProvider implements IRecogMatchersProvider, Serializab
       files.filter(filter::matches).forEach(file -> {
         try {
           final Path filePath = file.getFileName();
-          if (filePath != null)
-          {
+          if (filePath != null) {
             final String fileName = filePath.toString();
             try (Reader reader = Files.newBufferedReader(file)) {
               int extIndex = fileName.lastIndexOf(".xml");

--- a/recog/src/main/java/com/rapid7/recog/provider/RecogMatchersProvider.java
+++ b/recog/src/main/java/com/rapid7/recog/provider/RecogMatchersProvider.java
@@ -109,12 +109,16 @@ public class RecogMatchersProvider implements IRecogMatchersProvider, Serializab
     try (Stream<Path> files = Files.walk(path)) {
       files.filter(filter::matches).forEach(file -> {
         try {
-          final String fileName = file.getFileName().toString();
-          try (Reader reader = Files.newBufferedReader(file)) {
-            int extIndex = fileName.lastIndexOf(".xml");
-            RecogMatchers matchers = parser.parse(reader, extIndex > 0 ? fileName.substring(0, extIndex) : fileName);
-            matchersByFileName.put(fileName, matchers);
-            matchersByKey.put(matchers.getKey(), matchers);
+          final Path filePath = file.getFileName();
+          if (filePath != null)
+          {
+            final String fileName = filePath.toString();
+            try (Reader reader = Files.newBufferedReader(file)) {
+              int extIndex = fileName.lastIndexOf(".xml");
+              RecogMatchers matchers = parser.parse(reader, extIndex > 0 ? fileName.substring(0, extIndex) : fileName);
+              matchersByFileName.put(fileName, matchers);
+              matchersByKey.put(matchers.getKey(), matchers);
+            }
           }
         } catch (IOException | ParseException exception) {
           LOGGER.warn("Failed to parse document {}.", file, exception);


### PR DESCRIPTION
## Description
This adds a null check to the file paths we walk as part of parseFromWalkablePath

## Motivation and Context
When we changed from `Files.list(path)` to `Files.walk(path)` it caused a potential null pointer if the path is root (i.e. "/")
We believe this is the root cause of an issue being experienced by InsightVM customers.

## How Has This Been Tested?
Has been tested manually, but is hard to verify in unit tests due to the nature of walking the filesystem as part of the code


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
