### PR TITLE
Don't put matchers if we failed to parse

### DIFF
--- a/recog/src/main/java/com/rapid7/recog/parser/RecogParser.java
+++ b/recog/src/main/java/com/rapid7/recog/parser/RecogParser.java
@@ -105,7 +105,11 @@ public class RecogParser {
    */
   public RecogMatchers parse(Reader reader, String name)
       throws ParseException {
-    return parse(reader, null, name);
+    RecogMatchers matchers = parse(reader, null, name);
+    if (matchers == null) {
+      throw new ParseException("Failed to parse file: " + name);
+    }
+    return matchers;
   }
 
   /**

--- a/recog/src/main/java/com/rapid7/recog/parser/RecogParser.java
+++ b/recog/src/main/java/com/rapid7/recog/parser/RecogParser.java
@@ -105,11 +105,7 @@ public class RecogParser {
    */
   public RecogMatchers parse(Reader reader, String name)
       throws ParseException {
-    RecogMatchers matchers = parse(reader, null, name);
-    if (matchers == null) {
-      throw new ParseException("Failed to parse file: " + name);
-    }
-    return matchers;
+    return parse(reader, null, name);
   }
 
   /**
@@ -141,6 +137,9 @@ public class RecogParser {
       System.out.printf("parse(): exception.getMessage(): %s\n", exception.getMessage());
 
       throw new ParseException("Unable to parse fingerprints from Document", exception);
+    }
+    if (matchers == null) {
+      throw new ParseException("Failed to parse file: " + name);
     }
     return matchers;
   }

--- a/recog/src/main/java/com/rapid7/recog/provider/RecogMatchersProvider.java
+++ b/recog/src/main/java/com/rapid7/recog/provider/RecogMatchersProvider.java
@@ -113,12 +113,8 @@ public class RecogMatchersProvider implements IRecogMatchersProvider, Serializab
           try (Reader reader = Files.newBufferedReader(file)) {
             int extIndex = fileName.lastIndexOf(".xml");
             RecogMatchers matchers = parser.parse(reader, extIndex > 0 ? fileName.substring(0, extIndex) : fileName);
-            if (matchers != null) {
-              matchersByFileName.put(fileName, matchers);
-              matchersByKey.put(matchers.getKey(), matchers);
-            } else {
-              LOGGER.warn("Failed to parse file {}. Not adding to matchers.", file);
-            }
+            matchersByFileName.put(fileName, matchers);
+            matchersByKey.put(matchers.getKey(), matchers);
           }
         } catch (IOException | ParseException exception) {
           LOGGER.warn("Failed to parse document {}.", file, exception);

--- a/recog/src/main/java/com/rapid7/recog/provider/RecogMatchersProvider.java
+++ b/recog/src/main/java/com/rapid7/recog/provider/RecogMatchersProvider.java
@@ -113,8 +113,12 @@ public class RecogMatchersProvider implements IRecogMatchersProvider, Serializab
           try (Reader reader = Files.newBufferedReader(file)) {
             int extIndex = fileName.lastIndexOf(".xml");
             RecogMatchers matchers = parser.parse(reader, extIndex > 0 ? fileName.substring(0, extIndex) : fileName);
-            matchersByFileName.put(fileName, matchers);
-            matchersByKey.put(matchers.getKey(), matchers);
+            if (null != matchers) {
+              matchersByFileName.put(fileName, matchers);
+              matchersByKey.put(matchers.getKey(), matchers);
+            } else {
+              LOGGER.warn("Failed to parse file {}. Not adding to matchers.", file);
+            }
           }
         } catch (IOException | ParseException exception) {
           LOGGER.warn("Failed to parse document {}.", file, exception);

--- a/recog/src/main/java/com/rapid7/recog/provider/RecogMatchersProvider.java
+++ b/recog/src/main/java/com/rapid7/recog/provider/RecogMatchersProvider.java
@@ -113,7 +113,7 @@ public class RecogMatchersProvider implements IRecogMatchersProvider, Serializab
           try (Reader reader = Files.newBufferedReader(file)) {
             int extIndex = fileName.lastIndexOf(".xml");
             RecogMatchers matchers = parser.parse(reader, extIndex > 0 ? fileName.substring(0, extIndex) : fileName);
-            if (null != matchers) {
+            if (matchers != null) {
               matchersByFileName.put(fileName, matchers);
               matchersByKey.put(matchers.getKey(), matchers);
             } else {


### PR DESCRIPTION
## Description
If we fail to parse matchers from files we'll try and put a null into the maps. This causes null pointers when we try to get the key from the null matcher


## Motivation and Context
InsightVM does a bad job of separating its custom files sent to engines from consoles.
This leads to InsightVM style files being parsed by recog and causing nulls

## How Has This Been Tested?
Manually, I'm sorry.


## Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
- [ ] I have updated the documentation accordingly (or changes are not required).
- [ ] I have added tests to cover my changes (or new tests are not required).
- [ ] All new and existing tests passed.
