### PR TITLE
PD-45855: Move releases to github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Publish a release to the Maven Central Repository
+on: workflow_dispatch
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Maven Central Repository
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-passphrase: GPG_PASSPHRASE
+          gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
+      - name: Configure Git User
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
+      - name: Publish release
+        run: mvn -Dresume=false -Prelease -B -V -U release:prepare release:perform
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,25 @@
+name: Publish a snapshot to the Maven Central Repository
+on:
+  push:
+    branches: [ "master" ]
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Maven Central Repository
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-passphrase: GPG_PASSPHRASE
+          gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
+      - name: Publish snapshot
+        run: mvn deploy -B -C -U -Dprod -Pstyle-enforcer
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
   <description>Java implementation of Recog that supports parsing and matching.</description>
 
   <scm>
-    <connection>scm:git:git@github.com:rapid7/recog-java.git</connection>
-    <developerConnection>scm:git:git@github.com:rapid7/recog-java.git</developerConnection>
+    <connection>scm:git:https://github.com/rapid7/recog-java.git</connection>
+    <developerConnection>scm:git:https://github.com/rapid7/recog-java.git</developerConnection>
     <url>https://github.com/rapid7/recog-java</url>
     <tag>HEAD</tag>
   </scm>
@@ -268,7 +268,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.5</version>
+            <version>1.6</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -278,6 +278,13 @@
                 </goals>
               </execution>
             </executions>
+            <configuration>
+              <!-- Prevent gpg from using pinentry programs -->
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
## Description
Adding github actions workflows to test, build snapshots, and build releases for this repo. This is currently done in Jenkins but is being moved over to Github action as this repo is public.

## Motivation and Context
Public repo builds should be in github actions

## How Has This Been Tested?
Each workflow has been run in another similar repo

## Types of changes
No code changes, all build automation related changes

